### PR TITLE
Change plugin name from "Servicenow Plugin" to "ServiceNow"

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "mattermost-plugin-servicenow",
-    "name": "ServiceNow Plugin",
+    "name": "ServiceNow",
     "description": "This plugin serves as an integration between Mattermost and ServiceNow.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-servicenow",
     "support_url": "https://github.com/mattermost/mattermost-plugin-servicenow/issues",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "mattermost-plugin-servicenow",
-    "name": "Servicenow Plugin",
+    "name": "ServiceNow Plugin",
     "description": "This plugin serves as an integration between Mattermost and ServiceNow.",
     "homepage_url": "https://github.com/mattermost/mattermost-plugin-servicenow",
     "support_url": "https://github.com/mattermost/mattermost-plugin-servicenow/issues",


### PR DESCRIPTION
#### Summary

Capitalization was off, and we had a redundant "Plugin" in the title.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

