### PR TITLE
Update documentation to add steps to do on change of Webhook secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 - [Installation](#installation)
 - [Setup](#setup)
 - [Connecting to ServiceNow](#connecting-to-servicenow)
+- [FAQ](#faq)
 
 ## License
 
@@ -111,6 +112,43 @@ There are two methods by which you can connect your Mattermost account to your S
 
 After connecting successfully, you will get a direct message from the ServiceNow bot containing a Welcome message and some useful information along with some instructions for the system admins.
 **Note**: You will only get a direct message from the bot if your Mattermost server is configured to allow direct messages between any users on the server. If your server is configured to allow direct messages only between two users of the same team, then you will not get any direct message.
+
+## FAQ
+
+### What is Update Set that is present in the ServiceNow?
+
+An update set tracks and stores the changes of a ServiceNow instance and is used for moving those changes from one instance to another by first exporting this update set and importing the same update set to another ServiceNow instance. These changes can include things like some custom APIs (scripted REST APIs), changes in the tables, etc.
+
+### What changes does our Update Set do?
+
+- **GetStates scripted REST API**: Returns different states available for the records. Records supported: incident, task, change_task, and cert_follow_on_task
+
+- An application with the name **ServiceNow for Mattermost Notifications**
+
+    - **ServiceNow for Mattermost Notifications** application handles the storing of subscription details and sending notifications on the subscribed events.
+
+        - **ServiceNow for Mattermost Notifications Auth** table to store different Mattermost server URLs with their webhook secrets.
+
+        - **ServiceNow for Mattermost Subscriptions** table to store the subscription details.
+
+        - **Business rules** to handle different events (example: new record created, comment added on record, record state updated, etc.)
+
+        - **Script actions** to send notifications based on the subscription events.
+
+        - **Events registration** to register different record-type events.
+
+### Which ServiceNow tables are accessible through our plugin?
+
+- incident
+- problem
+- change_request
+- kb_knowledge
+- task
+- change_task
+- cert_follow_on_task
+- x_830655_mm_std_servicenow_for_mattermost_notifications_auth
+- x_830655_mm_std_servicenow_for_mattermost_subscriptions
+- All the tables extending these tables
 
 ---
 

--- a/docs/plugin_setup.md
+++ b/docs/plugin_setup.md
@@ -3,7 +3,7 @@
 - Go to the ServiceNow plugin configuration page on Mattermost as **System Console > Plugins > ServiceNow Plugin**.
 - On the ServiceNow plugin configuration page, you need to configure the following:
     - **ServiceNow Server Base URL**: Enter the base URL of your ServiceNow instance.
-    - **ServiceNow Webhook Secret**: Regenerate a new webhook secret. This webhook secret is used to authenticate HTTP requests from ServiceNow to Mattermost.
+    - **ServiceNow Webhook Secret**: Regenerate the webhook secret for ServiceNow Plugin. Regenerating this key will stop the subscription notifications. Refer to the documentation [here](./servicenow_setup.md), to update the secret in the ServiceNow instance and start receiving notifications again.
     - **ServiceNow OAuth Client ID**: The clientID of your registered OAuth app in ServiceNow.
     - **ServiceNow OAuth Client Secret**: The client secret of your registered OAuth app in ServiceNow.
     - **Encryption Secret**: Regenerate a new encryption secret. This encryption secret will be used to encrypt and decrypt the OAuth token.

--- a/docs/servicenow_setup.md
+++ b/docs/servicenow_setup.md
@@ -45,3 +45,10 @@ After the update is uploaded, it creates a new role called `x_830655_mm_std.user
     ![image](https://user-images.githubusercontent.com/77336594/186422364-0d5507ad-8392-4cd8-b1e6-93e9c7e44d90.png)
 
 - After the previous step, that user will have permission to add or manage subscriptions.
+
+## 5. Update the API secret on the change of ServiceNow Webhook Secret
+
+- Go to the ServiceNow instance and navigate to **All > x_830655_mm_std_servicenow_for_mattermost_notifications_auth.list**.
+- On the page, open the row consisting of your Mattermost Server URL.
+- Copy the Webhook Secret from the ServiceNow plugin configuration page on Mattermost from **System Console > Plugins > ServiceNow Plugin**.
+- Update the API Secret in the ServiceNow instance with the copied Webhook Secret from Mattermost and click on Update.

--- a/plugin.json
+++ b/plugin.json
@@ -37,8 +37,8 @@
                 "key": "WebhookSecret",
                 "display_name": "Webhook Secret:",
                 "type": "generated",
-                "help_text": "The webhook secret used by the ServiceNow API calls to Mattermost for sending notifications.",
-                "regenerate_help_text": "Regenerates the secret for ServiceNow Plugin. Regenerating this key invalidates any existing token.",
+                "help_text": "The webhook secret used by the ServiceNow API calls to Mattermost for sending notifications. Regenerating this key will stop the subscription notifications. Refer to the [documentation](https://github.com/mattermost/mattermost-plugin-servicenow) to update the secret in the ServiceNow instance and start receiving notifications again.",
+                "regenerate_help_text": "Regenerate a new webhook secret. This webhook secret is used to authenticate the HTTP requests from ServiceNow to Mattermost.",
                 "placeholder": "",
                 "default": null
             },


### PR DESCRIPTION
#### Summary

- Updated documentation to add the steps to perform when the system admin changes the `Webhook Secret` present in the ServiceNow plugin configuration page.  
- Added a `FAQ` section in the readme.