### PR TITLE
[GH-163]: Added the minimum supported mm version in the docs

### DIFF
--- a/docs/developer_docs.md
+++ b/docs/developer_docs.md
@@ -139,6 +139,8 @@ Make sure you have the following components installed:
 
 - Make
 
+- The minimum supported version for mattermost is v6.3.0.
+
 ### Building the plugin
 
 Run the following command in the plugin repo to prepare a compiled, distributable plugin zip:


### PR DESCRIPTION
#### Summary
Updated the read me to add the minimum supported mattermost version in the docs which is v6.3.0.
Issue: https://github.com/mattermost/mattermost-plugin-servicenow/issues/163https://github.com/mattermost/mattermost-plugin-servicenow/issues/163
